### PR TITLE
修复vivo Android5.1.1系统,阅读设置dialog顶部有多余白色背景问题

### DIFF
--- a/app/src/main/java/com/mp/android/apps/monke/readActivity/ui/ReadSettingDialog.java
+++ b/app/src/main/java/com/mp/android/apps/monke/readActivity/ui/ReadSettingDialog.java
@@ -114,6 +114,7 @@ public class ReadSettingDialog extends Dialog {
         lp.height = WindowManager.LayoutParams.WRAP_CONTENT;
         lp.gravity = Gravity.BOTTOM;
         window.setAttributes(lp);
+        window.getDecorView().setBackground(null);
     }
 
     private void initData() {


### PR DESCRIPTION
修复vivo Android5.1.1系统,阅读设置dialog顶部有多余白色背景问题